### PR TITLE
Modify Helm template output line limit

### DIFF
--- a/.github/actions/helm/local-chart-deploy/action.yml
+++ b/.github/actions/helm/local-chart-deploy/action.yml
@@ -44,8 +44,13 @@ runs:
         helm template ${{ inputs.chart }} \
           -f custom-values.yaml \
           --debug > rendered-all.yaml || true
+        awk '
+        /^# Source: .*grafana.yaml/ {skip=1}
+        /^# Source:/ && !/grafana.yaml/ {skip=0}
+        !skip
+        ' rendered-all.yaml > filtered.yaml  
     
-        nl -ba rendered-all.yaml | sed -n '1,300p'
+        nl -ba filtered.yaml | sed -n '1,500p'
       shell: bash
       
     - name: Deploy Helm Chart


### PR DESCRIPTION
Update the output filtering of rendered Helm templates to include the first 500 lines from filtered.yaml instead of 300 lines from rendered-all.yaml.